### PR TITLE
account for file icon

### DIFF
--- a/ace-link-dashboard.el
+++ b/ace-link-dashboard.el
@@ -36,6 +36,8 @@
 
 (require 'avy)
 
+(declare-function dashboard-remove-item-under "dashboard" nil)
+
 ;;;###autoload
 (defun ace-link-dashboard ()
   "Open a visible link in a `dashboard-mode' buffer."
@@ -75,7 +77,10 @@
       (goto-char (window-start))
       (while (< previous-point (funcall next-widget-point))
         (setq previous-point (point))
-        (push (cons (widget-at previous-point) previous-point) candidates))
+        (push (cons (widget-at previous-point) (if (eq 'unicode (char-charset (char-after (point))))
+                                                   (+ 2 previous-point)
+                                                 previous-point))
+              candidates))
       (nreverse candidates))))
 
 (provide 'ace-link-dashboard)


### PR DESCRIPTION
When `dashboard-set-file-icons` is non-nil, by default it adds a unicode file icon and a space before an item on dashboard.

Before this commit, when envoking either `ace-link-dashboard` or `ace-link-dashboard-remove`, the overlay drawn by `avy` appears on top of the unicode file icon and makes it unintelligible, regardless of the value of `avy-style`.

This commit detects unicode file icons when collecting the widgets and move forword the point past the icon and the padded space. Therefore the overlay would be drawn correctly on the item.

In addition, this commit also surpresses the warning the `dashboard-remove-item-under` is not defined.